### PR TITLE
feat: use new GA4 tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,13 @@
     <script type="module" src="/src/main.js"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-109005411-2"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-353746211"></script>
     <script>
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date());
      gtag('config', 'UA-109005411-2');
+     gtag('config', 'G-353746211');
     </script>
   </body>
 </html>


### PR DESCRIPTION
Migrate Datashare Landing page to Google Analytics 4.