### PR TITLE
refactor: iconify migration

### DIFF
--- a/bin/icons.ts
+++ b/bin/icons.ts
@@ -1,9 +1,0 @@
-import keys from 'lodash/keys.js'
-import pickBy from 'lodash/pickBy.js'
-import mapValues from 'lodash/mapValues.js'
-import * as all from '@phosphor-icons/vue'
-
-export const nameMatch = (name: string) => name.match(/^Ph[A-Z]/)
-export const components = pickBy(all, (value, key) => nameMatch(key))
-export const globals = mapValues(components, () => 'readonly')
-export const names = keys(components)

--- a/bin/presets/index.ts
+++ b/bin/presets/index.ts
@@ -1,1 +1,0 @@
-export { PhosphorVuePreset } from './phosphor-vue'

--- a/bin/presets/phosphor-vue.ts
+++ b/bin/presets/phosphor-vue.ts
@@ -1,7 +1,0 @@
-import { names } from '../icons'
-
-export function PhosphorVuePreset() {
-  return {
-    '@phosphor-icons/vue': names
-  }
-}

--- a/bin/resolvers/index.ts
+++ b/bin/resolvers/index.ts
@@ -1,1 +1,0 @@
-export { PhosphorVueResolver } from './phosphor-vue'

--- a/bin/resolvers/phosphor-vue.ts
+++ b/bin/resolvers/phosphor-vue.ts
@@ -1,9 +1,0 @@
-import { nameMatch } from '../icons'
-
-export function PhosphorVueResolver() {
-  return (name: string) => {
-    if (nameMatch(name)) {
-      return { name, from: '@phosphor-icons/vue' }
-    }
-  }
-}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,6 @@
 import globals from 'globals'
 import icijeslint from '@icij/eslint-config'
 
-import { globals as iconsGlobals } from './bin/icons.js'
-
 export default [
   {
     ignores: ['public']
@@ -38,7 +36,6 @@ export default [
   {
     languageOptions: {
       globals: {
-        ...iconsGlobals,
         // Vite uses process.env for environment variables
         process: true
       }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   },
   "dependencies": {
     "@icij/murmur-next": "^4.5.5",
-    "@phosphor-icons/vue": "^2.2.1",
     "bootstrap": "^5.3.7",
-    "bootstrap-vue-next": "^0.30.4",
+    "bootstrap-vue-next": "^0.42.0",
     "lodash": "^4.17.21",
     "ua-parser-js": "^2.0.4",
     "vue": "^3.5.17"
   },
   "devDependencies": {
     "@icij/eslint-config": "^3.0.3",
+    "@iconify-json/ph": "^1.2.2",
     "@tsconfig/node22": "^22.0.1",
     "@types/jsdom": "^21.1.7",
     "@types/lodash": "^4.17.20",
@@ -43,6 +43,7 @@
     "sass": "^1.79.3",
     "typescript": "^5.8.3",
     "unplugin-auto-import": "^19.3.0",
+    "unplugin-icons": "^23.0.1",
     "unplugin-vue-components": "^28.8.0",
     "vite": "^7.0.5",
     "vite-plugin-vue-devtools": "^7.7.7",

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,7 @@ const alertExpiration = 'Feb 15 2026'
 </script>
 
 <template>
-  <div>
+  <b-app>
     <app-nav-bar id="app-nav-bar" />
     <div
       id="nav-scroller"
@@ -78,7 +78,7 @@ const alertExpiration = 'Feb 15 2026'
       <app-alert :expiration-date="alertExpiration" />
     </div>
     <generic-footer />
-  </div>
+  </b-app>
 </template>
 
 <style scoped lang="scss"></style>

--- a/src/components/AppDatashareContribute.vue
+++ b/src/components/AppDatashareContribute.vue
@@ -4,17 +4,22 @@ import { ref, computed } from 'vue'
 import { useColorModePersisted } from '@/composables/useColorModePersisted.ts'
 import AppSection from '@/components/AppSection.vue'
 
+import IPhHandHeart from '~icons/ph/hand-heart'
+import IPhHandHeartFill from '~icons/ph/hand-heart-fill'
+import IPhGithubLogo from '~icons/ph/github-logo'
+import IPhTranslate from '~icons/ph/translate'
+
 const datashareGithubURL = 'https://github.com/ICIJ/datashare'
 const translateURL = 'https://crowdin.com/project/datashare'
-const weight = ref('regular')
-const iconVariant = ref<'primary' | null>(null)
+const isFilled = ref(false)
 const { isDark } = useColorModePersisted()
 const buttonVariant = computed(() => isDark.value ? 'light' : 'action')
 const btnClassList = computed(() => ({ 'bg-white': isDark.value }))
 
+const donateIcon = computed(() => isFilled.value ? IPhHandHeartFill : IPhHandHeart)
+
 function toggleIcijLink() {
-  iconVariant.value = iconVariant.value === null ? 'primary' : null
-  weight.value = weight.value === 'regular' ? 'fill' : 'regular'
+  isFilled.value = !isFilled.value
 }
 </script>
 
@@ -51,10 +56,8 @@ function toggleIcijLink() {
             rel="noreferrer noopener"
             size="lg"
             target="_blank"
-            icon-left="hand-heart"
+            :icon-left="donateIcon"
             :variant="buttonVariant"
-            :icon-left-weight="weight"
-            :icon-left-variant="iconVariant"
             @mouseenter="toggleIcijLink"
             @mouseleave="toggleIcijLink"
           >
@@ -66,7 +69,7 @@ function toggleIcijLink() {
             :href="datashareGithubURL"
             variant="outline-action"
             size="lg"
-            icon-left="github-logo"
+            :icon-left="IPhGithubLogo"
             class="action-link p-4"
           >
             Contribute
@@ -77,7 +80,7 @@ function toggleIcijLink() {
             :href="translateURL"
             variant="outline-action"
             size="lg"
-            icon-left="translate"
+            :icon-left="IPhTranslate"
             class="action-link p-4"
           >
             Help us translate

--- a/src/components/AppDatashareDemo.vue
+++ b/src/components/AppDatashareDemo.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { PhEyes } from '@phosphor-icons/vue'
 
 import { THEME } from '@/utils/enum.ts'
 import { useColorModePersisted } from '@/composables/useColorModePersisted.ts'
@@ -26,10 +25,7 @@ const isDarkSelected = computed(() => colorMode.value === THEME.DARK)
         Want to dive into the <span class="fw-bold text-nowrap"> Lux Leaks</span> documents?
         <span class="text-nowrap gap-1">
           Try our <a href="https://datashare-demo.icij.org">demo</a>
-          <PhEyes
-            weight="fill"
-            class="ms-1 mb-1"
-          />
+          <i-ph-eyes-fill class="ms-1 mb-1" />
         </span>
       </h3>
       <div class="align-self-center col-10">

--- a/src/components/AppDatashareResources.vue
+++ b/src/components/AppDatashareResources.vue
@@ -2,10 +2,15 @@
 import AppSection from '@/components/AppSection.vue'
 import DatashareResourceCard from '@/components/DatashareResource/DatashareResourceCard.vue'
 
+import IPhListMagnifyingGlass from '~icons/ph/list-magnifying-glass'
+import IPhHandWavingFill from '~icons/ph/hand-waving-fill'
+import IPhCodeBlockFill from '~icons/ph/code-block-fill'
+import IPhPuzzlePieceFill from '~icons/ph/puzzle-piece-fill'
+
 const resources = {
   search: {
     title: 'Search in your documents effi&shy;cien&shy;tly',
-    icon: 'ListMagnifyingGlass',
+    icon: IPhListMagnifyingGlass,
     iconColor: 'primary',
     externalLink: 'https://icij.gitbook.io/datashare/usage/search-documents',
     content:
@@ -13,27 +18,24 @@ const resources = {
   },
   collaboration: {
     title: 'Colla&shy;bo&shy;ra&shy;ti&shy;ve&shy;ly work on a server',
-    icon: 'hand-waving',
+    icon: IPhHandWavingFill,
     iconColor: 'warning',
-    iconWeight: 'fill',
     externalLink: 'https://icij.gitbook.io/datashare/server-mode/about-the-server-mode',
     content:
       'Self-host and set up your own online instance to work as a team on the same documents. Use social features like tags and recommendations'
   },
   api: {
     title: 'Query your data with API',
-    icon: 'code-block',
+    icon: IPhCodeBlockFill,
     iconColor: 'success',
-    iconWeight: 'fill',
     externalLink: 'https://icij.gitbook.io/datashare/developers/backend/api',
     content:
       'In the local version, all data is on your computer and you have multiple ways to explore what your documents contain'
   },
   modular: {
     title: 'Install plugins and exten&shy;sions',
-    icon: 'puzzle-piece',
+    icon: IPhPuzzlePieceFill,
     iconColor: 'info',
-    iconWeight: 'fill',
     externalLink: 'https://icij.gitbook.io/datashare/local-mode/plugins-and-extensions',
     content:
       'Run analytics, filter by email addresses, add sentence case, paginate text or add your own custom plugin/extension'

--- a/src/components/AppJumbotron.vue
+++ b/src/components/AppJumbotron.vue
@@ -8,6 +8,9 @@ import { DEFAULT_ICON, useOs } from '@/composables/useOs.ts'
 import { useRelease } from '@/composables/useRelease.ts'
 import AppSection from '@/components/AppSection.vue'
 import { ReleasesKey } from '@/utils/types.ts'
+
+import IPhEyesFill from '~icons/ph/eyes-fill'
+
 const { detectedOs, isCompatible } = useOs()
 
 const releases = inject(ReleasesKey)
@@ -49,8 +52,7 @@ const label = computed(() => {
         </div>
         <div>
           <button-icon
-            icon-right="eyes"
-            icon-right-weight="fill"
+            :icon-right="IPhEyesFill"
             variant="outline-action"
             class="demo-link bg-body text-action-emphasis border-action-emphasis"
             href="https://datashare-demo.icij.org/"

--- a/src/components/AppModal/AppModalHeader.vue
+++ b/src/components/AppModal/AppModalHeader.vue
@@ -2,6 +2,8 @@
 
 import type { AppModalHeaderProps } from '@/utils/types.ts'
 
+import IPhX from '~icons/ph/x'
+
 defineEmits(['close'])
 withDefaults(defineProps<AppModalHeaderProps>(), { noHeaderClose: false })
 </script>
@@ -11,7 +13,7 @@ withDefaults(defineProps<AppModalHeaderProps>(), { noHeaderClose: false })
     <slot name="close">
       <button-icon
         v-if="!noHeaderClose"
-        icon-left="x"
+        :icon-left="IPhX"
         hide-label
         hide-tooltip
         variant="outline-secondary"

--- a/src/components/AppNavBar.vue
+++ b/src/components/AppNavBar.vue
@@ -8,15 +8,18 @@ import TabGroupNavigation from '@/components/TabGroup/TabGroupNavigation/TabGrou
 import TabGroupNavigationEntry from '@/components/TabGroup/TabGroupNavigation/TabGroupNavigationEntry.vue'
 import ThemeDropdown from '@/components/ThemeDropdown.vue'
 
+import IPhHandHeart from '~icons/ph/hand-heart'
+import IPhHandHeartFill from '~icons/ph/hand-heart-fill'
+
 const { detectedOs, osDescription, isCompatible } = useOs()
 const { isDark } = useColorModePersisted()
 
-const weight = ref<'regular' | 'fill'>('regular')
+const isFilled = ref(false)
 const variant = ref('body')
 
 function toggleIcijLink() {
   variant.value = variant.value === 'body' ? 'primary' : 'body'
-  weight.value = weight.value === 'regular' ? 'fill' : 'regular'
+  isFilled.value = !isFilled.value
 }
 
 const osIcon = computed(() => {
@@ -62,7 +65,7 @@ const togglerClassList = computed(() => {
         :class="togglerClassList"
       >
         <template #default>
-          <phosphor-icon name="list" />
+          <i-ph-list />
         </template>
       </b-navbar-toggle>
       <b-collapse
@@ -71,19 +74,16 @@ const togglerClassList = computed(() => {
       >
         <tab-group-navigation class="pt-1">
           <tab-group-navigation-entry href="#download">
-            <phosphor-icon :name="osIcon" />Download
+            <component :is="osIcon" />Download
           </tab-group-navigation-entry>
           <tab-group-navigation-entry href="#demo">
-            <phosphor-icon
-              name="eyes"
-              weight="fill"
-            />Demo
+            <i-ph-eyes-fill />Demo
           </tab-group-navigation-entry>
           <tab-group-navigation-entry href="#learn">
-            <phosphor-icon name="student" />Learn
+            <i-ph-student />Learn
           </tab-group-navigation-entry>
           <tab-group-navigation-entry href="#contribute">
-            <phosphor-icon name="github-logo" />Contribute
+            <i-ph-github-logo />Contribute
           </tab-group-navigation-entry>
           <tab-group-navigation-entry
             href="https://icij.org/donate"
@@ -93,10 +93,9 @@ const togglerClassList = computed(() => {
             @mouseenter="toggleIcijLink"
             @mouseleave="toggleIcijLink"
           >
-            <phosphor-icon
-              name="hand-heart"
-              :weight="weight"
-              :variant="variant"
+            <component
+              :is="isFilled ? IPhHandHeartFill : IPhHandHeart"
+              :class="{ 'text-primary': variant === 'primary' }"
             />
             It's free! Support ICIJ
           </tab-group-navigation-entry>

--- a/src/components/ColorModeSelector.vue
+++ b/src/components/ColorModeSelector.vue
@@ -4,10 +4,15 @@ import { computed } from 'vue'
 import { THEME } from '@/utils/enum.ts'
 import type { Theme } from '@/utils/types.ts'
 
+import IPhSun from '~icons/ph/sun'
+import IPhSunFill from '~icons/ph/sun-fill'
+import IPhMoon from '~icons/ph/moon'
+import IPhMoonFill from '~icons/ph/moon-fill'
+
 const colorMode = defineModel<Theme>({ default: THEME.LIGHT })
 const isDark = computed(() => colorMode.value === THEME.DARK)
-const isLightActive = computed(() => !isDark.value ? 'fill' : 'regular')
-const isDarkActive = computed(() => isDark.value ? 'fill' : 'regular')
+const lightIcon = computed(() => !isDark.value ? IPhSunFill : IPhSun)
+const darkIcon = computed(() => isDark.value ? IPhMoonFill : IPhMoon)
 </script>
 
 <template>
@@ -18,10 +23,7 @@ const isDarkActive = computed(() => isDark.value ? 'fill' : 'regular')
         class="color-mode-selector__radio"
       >
         <span class="d-inline-flex align-items-center gap-1">
-          <phosphor-icon
-            name="sun"
-            :weight="isLightActive"
-          />
+          <component :is="lightIcon" />
           Light mode
         </span>
       </b-form-radio>
@@ -30,10 +32,7 @@ const isDarkActive = computed(() => isDark.value ? 'fill' : 'regular')
         class="color-mode-selector__radio"
       >
         <span class="d-inline-flex align-items-center gap-1">
-          <phosphor-icon
-            name="moon"
-            :weight="isDarkActive"
-          />
+          <component :is="darkIcon" />
           Dark mode
         </span>
       </b-form-radio>

--- a/src/components/DatashareDownloadModal/DatashareDownloadModalToggleExperimental.vue
+++ b/src/components/DatashareDownloadModal/DatashareDownloadModalToggleExperimental.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
+import IPhFlask from '~icons/ph/flask'
+import IPhFlaskFill from '~icons/ph/flask-fill'
+import { computed } from 'vue'
+
 const showExperimentalVersion = defineModel({ type: Boolean })
+
+const flaskIcon = computed(() => showExperimentalVersion.value ? IPhFlaskFill : IPhFlask)
 </script>
 
 <template>
@@ -15,11 +21,10 @@ const showExperimentalVersion = defineModel({ type: Boolean })
       >
         Show experimental versions
       </span>
-      <phosphor-icon
-        :fill="showExperimentalVersion"
-        name="flask"
+      <component
+        :is="flaskIcon"
         title="Experimental version"
-        variant="info"
+        class="text-info"
       />
     </b-form-checkbox>
     <span class="text-body-tertiary small">Experimental versions are unstable and might present bugs. Use them at your own risk.</span>

--- a/src/components/DatashareResource/DatashareResourceCard.vue
+++ b/src/components/DatashareResource/DatashareResourceCard.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import SvgLinearGradient from '@/components/SvgLinearGradient.vue'
 
 const props = defineProps<{
-  icon?: string
+  icon?: Component
   iconColor: string
-  iconWeight?: string
   title?: string
   content?: string
   externalLink?: string
@@ -33,10 +32,9 @@ const iconColorStyle = computed(() => {
         :icon-color-id="iconColorId"
       />
       <slot name="icon">
-        <PhosphorIcon
-          :name="icon"
-          :weight="iconWeight"
-          size="50px"
+        <component
+          :is="icon"
+          class="datashare-resource-card__icon"
         />
       </slot>
     </div>
@@ -48,7 +46,7 @@ const iconColorStyle = computed(() => {
       <slot>{{ content }}</slot>
     </p>
 
-    <a :href="externalLink">Learn more<PhArrowUpRight class="ms-1" /></a>
+    <a :href="externalLink">Learn more<i-ph-arrow-up-right class="ms-1" /></a>
   </b-card>
 </template>
 
@@ -66,7 +64,10 @@ const iconColorStyle = computed(() => {
     flex: 1 1 250px !important;
     width: 25%;
   }
-  .phosphor-icon {
+  &__icon {
+    width: 50px;
+    height: 50px;
+
     svg {
       fill: v-bind(iconColorStyle);
     }

--- a/src/components/Download/ButtonDownload.vue
+++ b/src/components/Download/ButtonDownload.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import { useColorModePersisted } from '@/composables/useColorModePersisted.ts'
 
-defineProps({
-  asset: { type: String },
-  size: { type: String },
-  icon: { type: String },
-  label: { type: String }
-})
+defineProps<{
+  asset?: string
+  size?: string
+  icon?: Component
+  label?: string
+}>()
 
 const { isDark } = useColorModePersisted()
 const variant = computed(() => (isDark.value ? 'light' : 'action'))

--- a/src/components/Download/DownloadButtons.vue
+++ b/src/components/Download/DownloadButtons.vue
@@ -8,6 +8,8 @@ import { useAssets } from '@/composables/useAssets.ts'
 import DatashareDownloadModal from '@/components/DatashareDownloadModal/DatashareDownloadModal.vue'
 import { ReleasesKey } from '@/utils/types.ts'
 
+import IPhDownloadSimple from '~icons/ph/download-simple'
+
 defineOptions({ name: 'DownloadButtons' })
 const props = defineProps<{ osValue: OsType }>()
 
@@ -39,7 +41,7 @@ const { osButton } = useAssets(props.osValue, latestAssets)
     </div>
     <div v-else>
       <button-icon
-        icon-left="download-simple"
+        :icon-left="IPhDownloadSimple"
         variant="secondary"
         class=" p-4"
         size="lg"

--- a/src/components/Download/DownloadDocker.vue
+++ b/src/components/Download/DownloadDocker.vue
@@ -6,6 +6,9 @@ import dockerComposeYmlRaw from '@/assets/docker-compose.yml?raw'
 import CopyInput from '@/components/Download/CopyInput.vue'
 import { ReleasesKey } from '@/utils/types.ts'
 
+import IPhCaretUp from '~icons/ph/caret-up'
+import IPhCaretDown from '~icons/ph/caret-down'
+
 defineOptions({ name: 'DownloadDocker' })
 
 const releases = inject(ReleasesKey)
@@ -22,7 +25,7 @@ const dockerComposeYmlHref = computed(() => {
   return 'data:text/plain;charset=utf-8,' + encodeURIComponent(dockerComposeYml.value)
 })
 const dockerComposeYmlCaret = computed(() => {
-  return dockerComposeYmlVisible.value ? 'caret-up' : 'caret-down'
+  return dockerComposeYmlVisible.value ? IPhCaretUp : IPhCaretDown
 })
 </script>
 
@@ -57,7 +60,7 @@ const dockerComposeYmlCaret = computed(() => {
       <div class="d-flex">
         <button-icon
           v-b-toggle.docker-compose-yml
-          :left-icon="dockerComposeYmlCaret"
+          :icon-left="dockerComposeYmlCaret"
           variant="link"
           class="text-left text-bg-body flex-grow-1"
         >

--- a/src/components/Download/DownloadList.vue
+++ b/src/components/Download/DownloadList.vue
@@ -90,15 +90,13 @@ const filteredReleases = computed(() => {
                     :href="release.downloadUrl"
                     class="download-list__row__version__link font-weight-bold d-inline-flex gap-2 fw-bold"
                   >
-                    <phosphor-icon name="download-simple" />
+                    <i-ph-download-simple />
                     <span>{{ release.name }}</span>
                   </a>
-                  <phosphor-icon
+                  <i-ph-flask-fill
                     v-if="release.prerelease"
-                    fill
-                    name="flask"
                     title="Experimental version"
-                    variant="info"
+                    class="text-info"
                   />
                 </div>
                 <div class="download-list__row__info d-flex gap-2">

--- a/src/components/Download/DownloadVariants.vue
+++ b/src/components/Download/DownloadVariants.vue
@@ -7,6 +7,8 @@ import { OS, osDescription, simpleOs, useOs } from '@/composables/useOs'
 import TabGroup from '@/components/TabGroup/TabGroup.vue'
 import TabGroupEntry from '@/components/TabGroup/TabGroupEntry.vue'
 
+import IPhGithubLogo from '~icons/ph/github-logo'
+
 defineOptions({
   name: 'DownloadVariants'
 })
@@ -65,7 +67,7 @@ const tabs = [
         :active="tab.active()"
       >
         <template #title>
-          <phosphor-icon :name="tab.icon" /> {{ tab.name }}
+          <component :is="tab.icon" /> {{ tab.name }}
         </template>
         <download-list
           v-model="showExperimentalVersions"
@@ -78,7 +80,7 @@ const tabs = [
         no-body
       >
         <template #title>
-          <phosphor-icon :name="simpleOs[OS.SNAP].icon" /> {{ simpleOs[OS.SNAP].name }}
+          <component :is="simpleOs[OS.SNAP].icon" /> {{ simpleOs[OS.SNAP].name }}
         </template>
         <download-snap v-model="showExperimentalVersions" />
       </tab-group-entry>
@@ -87,13 +89,13 @@ const tabs = [
         lazy
       >
         <template #title>
-          <phosphor-icon :name="simpleOs[OS.DOCKER].icon" /> {{ simpleOs[OS.DOCKER].name }}
+          <component :is="simpleOs[OS.DOCKER].icon" /> {{ simpleOs[OS.DOCKER].name }}
         </template>
         <download-docker />
       </tab-group-entry>
     </tab-group>
     <button-icon
-      icon-left="github-logo"
+      :icon-left="IPhGithubLogo"
       variant="outline-secondary"
       class="align-self-end"
       href="https://github.com/ICIJ/datashare/releases"

--- a/src/components/TabGroup/TabGroupTitle.vue
+++ b/src/components/TabGroup/TabGroupTitle.vue
@@ -1,35 +1,29 @@
 <script setup lang="ts">
-defineProps({
-  icon: {
-    type: [String, Object, Array]
-  },
-  count: {
-    type: Number,
-    default: null
-  }
-})
+import { type Component } from 'vue'
+
+defineProps<{
+  icon?: Component
+  count?: number | null
+}>()
 </script>
 
 <template>
   <span class="tab-group-title d-flex gap-1">
     <template v-if="icon">
-      <phosphor-icon
-        :name="icon"
+      <component
+        :is="icon"
         class="tab-group-title__icon tab-group-title__icon--inactive"
-        size="1.25em"
         aria-hidden="true"
       />
-      <phosphor-icon
-        :name="icon"
+      <component
+        :is="icon"
         class="tab-group-title__icon tab-group-title__icon--active"
-        weight="bold"
-        size="1.25em"
         aria-hidden="true"
       />
     </template>
     <slot />
     <b-badge
-      v-if="count !== null"
+      v-if="count !== null && count !== undefined"
       :variant="null"
       pill
     >

--- a/src/components/ThemeDropdown.vue
+++ b/src/components/ThemeDropdown.vue
@@ -1,30 +1,42 @@
 <script setup lang="ts">
 import { useColorMode } from 'bootstrap-vue-next'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import type { Theme } from '@/utils/types.ts'
 import ThemeDropdownItem from '@/components/ThemeDropdownItem.vue'
 import { THEME } from '@/utils/enum.ts'
 
-const themes: Record<string, { icon: string
+import IPhSun from '~icons/ph/sun'
+import IPhSunFill from '~icons/ph/sun-fill'
+import IPhMoon from '~icons/ph/moon'
+import IPhMoonFill from '~icons/ph/moon-fill'
+import IPhPaintRoller from '~icons/ph/paint-roller'
+import IPhPaintRollerFill from '~icons/ph/paint-roller-fill'
+
+const themes: Record<string, {
+  icon: Component
+  iconFill: Component
   theme: Theme
   label: string
   title: string
-  weight?: string }> = {
+}> = {
   light: {
-    icon: 'sun',
+    icon: IPhSun,
+    iconFill: IPhSunFill,
     theme: 'light',
     title: 'Theme Light',
     label: 'Light'
   },
   dark: {
-    icon: 'moon',
+    icon: IPhMoon,
+    iconFill: IPhMoonFill,
     theme: 'dark',
     title: 'Theme Dark',
     label: 'Dark'
   },
   auto: {
-    icon: 'paint-roller',
+    icon: IPhPaintRoller,
+    iconFill: IPhPaintRollerFill,
     theme: 'auto',
     title: 'Theme Auto',
     label: 'Auto',
@@ -33,8 +45,10 @@ const themes: Record<string, { icon: string
 
 const mode = useColorMode({ persist: true })
 const currentTitle = computed(() => themes[mode.store.value].title)
-const currentIcon = computed(() => themes[mode.store.value].icon)
-const iconWeight = computed(() => mode.value === THEME.DARK ? 'fill' : 'regular')
+const currentIcon = computed(() => {
+  const themeConfig = themes[mode.store.value]
+  return mode.value === THEME.DARK ? themeConfig.iconFill : themeConfig.icon
+})
 
 function updateTheme(newTheme: Theme) {
   mode.value = newTheme
@@ -46,9 +60,8 @@ function updateTheme(newTheme: Theme) {
     right
   >
     <template #button-content>
-      <phosphor-icon
-        :name="currentIcon"
-        :weight="iconWeight"
+      <component
+        :is="currentIcon"
         :title="currentTitle"
       />
     </template>

--- a/src/components/ThemeDropdownItem.vue
+++ b/src/components/ThemeDropdownItem.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
 import { useColorMode } from 'bootstrap-vue-next'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import type { Theme } from '@/utils/types.ts'
 
 const mode = useColorMode({ persist: true })
-const props = defineProps<{ theme: Theme, label: string, icon: string, weight?: string }>()
+const props = defineProps<{
+  theme: Theme
+  label: string
+  icon: Component
+  iconFill: Component
+}>()
 
 defineEmits(['update'])
 
-const iconWeight = computed(() => {
-  if (props.weight) return props.weight
-  return mode.value === 'light' ? 'regular' : 'fill'
+const currentIcon = computed(() => {
+  return mode.value === 'light' ? props.icon : props.iconFill
 })
 
 const isActive = computed(() => {
@@ -26,10 +30,7 @@ const isActive = computed(() => {
     @click="$emit('update',theme)"
   >
     <span class="text-action-emphasis ">
-      <phosphor-icon
-        :name="icon"
-        :weight="iconWeight"
-      />
+      <component :is="currentIcon" />
       {{ label }}
     </span>
   </b-dropdown-item>

--- a/src/composables/useOs.ts
+++ b/src/composables/useOs.ts
@@ -1,5 +1,13 @@
 import { UAParser } from 'ua-parser-js'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
+
+import IPhAppleLogo from '~icons/ph/apple-logo'
+import IPhWindowsLogo from '~icons/ph/windows-logo'
+import IPhLinuxLogo from '~icons/ph/linux-logo'
+import IPhBird from '~icons/ph/bird'
+import IPhShippingContainer from '~icons/ph/shipping-container'
+import IPhCoffee from '~icons/ph/coffee'
+import IPhDownloadSimple from '~icons/ph/download-simple'
 
 export enum OS {
   MACOS = 'macos',
@@ -13,11 +21,11 @@ export enum OS {
   OTHER = 'other'
 }
 export type OsType = `${OS}`
-export const DEFAULT_ICON = 'download-simple'
+export const DEFAULT_ICON = IPhDownloadSimple
 
 interface OSAssetSimple {
   name: string
-  icon: string
+  icon: Component
   description: string
 }
 
@@ -29,7 +37,7 @@ type OSAsset = OSAssetSimple & {
   buttons: {
     label: string
     asset?: string | null
-    icon?: string
+    icon?: Component
     btnSize?: string
     wrapperClass?: string
     guide?: boolean
@@ -39,12 +47,12 @@ type OSAsset = OSAssetSimple & {
 export const simpleOs: Record<string, OSAssetSimple> = {
   [OS.SNAP]: {
     name: 'Snap',
-    icon: 'bird',
+    icon: IPhBird,
     description: 'List of Snap packages to Datashare application on Ubuntu.'
   },
   [OS.DOCKER]: {
     name: 'Docker',
-    icon: 'shipping-container',
+    icon: IPhShippingContainer,
     description: 'Run datashare as a Docker container.'
   }
 }
@@ -52,7 +60,7 @@ export const simpleOs: Record<string, OSAssetSimple> = {
 export const osDescription: Record<string, OSAsset> = {
   [OS.MACOS]: {
     name: 'Mac',
-    icon: 'apple-logo',
+    icon: IPhAppleLogo,
     description: 'List of installer packages (.pkg) to run Datashare on macOS.',
     ext: ['.pkg', 'DatashareStandalone.pkg'],
     guide: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-mac',
@@ -61,7 +69,7 @@ export const osDescription: Record<string, OSAsset> = {
   },
   [OS.WINDOWS]: {
     name: 'Windows',
-    icon: 'windows-logo',
+    icon: IPhWindowsLogo,
     description: 'List of executables (.exe) to run Datashare on Windows.',
     ext: ['.exe', 'installDatashareStandalone.exe'],
     guide: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-windows',
@@ -70,17 +78,17 @@ export const osDescription: Record<string, OSAsset> = {
   },
   [OS.DEBIAN]: {
     name: 'Debian',
-    icon: 'linux-logo',
+    icon: IPhLinuxLogo,
     description: 'List of Debian packages (.deb) to run Datashare on Debian-based system like Ubuntu.',
     ext: ['.deb'],
     guide: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-linux',
     asset: null,
     buttons: [
-      { label: 'Download .deb', asset: null, icon: 'linux-logo' },
+      { label: 'Download .deb', asset: null, icon: IPhLinuxLogo },
       {
         label: 'Download .tgz',
         asset: null,
-        icon: 'coffee',
+        icon: IPhCoffee,
         btnSize: 'xs',
         wrapperClass: 'small',
         guide: false
@@ -89,17 +97,17 @@ export const osDescription: Record<string, OSAsset> = {
   },
   [OS.LINUX]: {
     name: 'Linux',
-    icon: 'linux-logo',
+    icon: IPhLinuxLogo,
     description: 'List of archives (.tar.gz) containing Datashare as a JAR (Java Archive) packaged application.',
     ext: ['.tgz'],
     guide: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-linux',
     asset: null,
     buttons: [
-      { label: 'Download .deb', asset: null, icon: 'linux-logo' },
+      { label: 'Download .deb', asset: null, icon: IPhLinuxLogo },
       {
         label: 'Download .tgz',
         asset: null,
-        icon: 'coffee',
+        icon: IPhCoffee,
         btnSize: 'xs',
         wrapperClass: 'small',
         guide: false
@@ -108,13 +116,13 @@ export const osDescription: Record<string, OSAsset> = {
   },
   [OS.OTHER]: {
     name: 'Java',
-    icon: 'coffee',
+    icon: IPhCoffee,
     ext: ['.tgz'],
     description: 'List of archives (.tar.gz) containing Datashare as a JAR (Java Archive) packaged application.',
     guide: 'https://icij.gitbook.io/datashare/local-mode/install-datashare-on-linux',
     asset: null,
     buttons: [
-      { label: 'Download .tar.gz', asset: null, icon: 'coffee' },
+      { label: 'Download .tar.gz', asset: null, icon: IPhCoffee },
     ]
   }
 }

--- a/src/icons.d.ts
+++ b/src/icons.d.ts
@@ -1,0 +1,5 @@
+declare module '~icons/*' {
+  import type { FunctionalComponent, SVGAttributes } from 'vue'
+  const component: FunctionalComponent<SVGAttributes>
+  export default component
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,9 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 import Components from 'unplugin-vue-components/vite'
 import AutoImport from 'unplugin-auto-import/vite'
 import { BootstrapVueNextResolver } from 'bootstrap-vue-next'
+import Icons from 'unplugin-icons/vite'
+import IconsResolver from 'unplugin-icons/resolver'
 
-import { PhosphorVueResolver } from './bin/resolvers'
-import { PhosphorVuePreset } from './bin/presets'
-// https://vite.dev/config/
 export default defineConfig({
   base: '/',
   plugins: [
@@ -27,22 +26,32 @@ export default defineConfig({
     vueDevTools(),
     /**
      * The "Components" plugin resolvers imports automatically component in vue
-     * templates For PhosphorVueResolver we use an homemade resolver
-     * that simply imports icons (example: `<ph-plus>`).
+     * templates. IconsResolver auto-imports icons using `<i-ph-*>` syntax.
      */
     Components({
-      resolvers: [BootstrapVueNextResolver(), PhosphorVueResolver()]
+      resolvers: [
+        BootstrapVueNextResolver(),
+        IconsResolver({ prefix: 'i', enabledCollections: ['ph'] })
+      ]
     }),
     /**
      * The "AutoImport" plugin offer a mechanism similar to the "Components" plugins
-     * but it targets javascript variable and references. This allows to imports component
-     * directly in `<script setup>` or in vue template ref (example: `<component :is="PhPlus" />`)
+     * but it targets javascript variable and references.
      */
     AutoImport({
       dts: false,
       vueTemplate: true,
-      imports: [PhosphorVuePreset()],
-      resolvers: [PhosphorVueResolver()]
+      imports: [],
+      resolvers: [IconsResolver({ prefix: 'i', enabledCollections: ['ph'] })]
+    }),
+    /**
+     * The "Icons" plugin generates icon components from Iconify collections.
+     * Icons are used via <i-{collection}-{icon}> syntax (e.g., <i-ph-user />).
+     */
+    Icons({
+      scale: 1.25,
+      compiler: 'vue3',
+      autoInstall: true
     })
   ],
   resolve: {
@@ -64,8 +73,6 @@ export default defineConfig({
       }
     }
   },
-  optimizeDeps: {
-    exclude: ['@phosphor-icons/vue']
-  }
+  optimizeDeps: {}
 
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@antfu/install-pkg@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+  dependencies:
+    package-manager-detector "^1.3.0"
+    tinyexec "^1.0.1"
+
 "@antfu/utils@^0.7.10":
   version "0.7.10"
   resolved "https://registry.yarnpkg.com/@antfu/utils/-/utils-0.7.10.tgz#ae829f170158e297a9b6a28f161a8e487d00814d"
@@ -575,6 +583,27 @@
     vue-input-autowidth "^2.2.1"
     vue-virtual-scroller "^2.0.0-beta.8"
 
+"@iconify-json/ph@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@iconify-json/ph/-/ph-1.2.2.tgz#eac734e80f4639df6ade990690a825540b4259c4"
+  integrity sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw==
+  dependencies:
+    "@iconify/types" "*"
+
+"@iconify/types@*", "@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-3.1.0.tgz#fb41882915f97fee6f91a2fbb8263e8772ca0438"
+  integrity sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/types" "^2.0.0"
+    mlly "^1.8.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -594,6 +623,14 @@
   dependencies:
     "@jridgewell/set-array" "^1.2.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/resolve-uri@^3.1.0":
@@ -1611,10 +1648,10 @@ bootstrap-vue-next@0.30.3:
   resolved "https://registry.yarnpkg.com/bootstrap-vue-next/-/bootstrap-vue-next-0.30.3.tgz#890cfc9b5977aad937d8b1ff00ce00f02bf37744"
   integrity sha512-cP2WVu7hD9za7Ad9jXKr8yQO5O954pp4gkog3u04NUh1afgB+aFbjq/vK1R5Ozfb0VkpH9p5A2YyFhIU69qDOQ==
 
-bootstrap-vue-next@^0.30.4:
-  version "0.30.4"
-  resolved "https://registry.yarnpkg.com/bootstrap-vue-next/-/bootstrap-vue-next-0.30.4.tgz#bca0d4fefef426f6407c0e8f825a8bba2e04db54"
-  integrity sha512-F5aTBYkHrXjUK2ont/VdsCpBifrP9YAPUA2+FUVgl1Ff481zfgYxBpJ9syFCFEFNdPsvertlP6gXaGAvpIXq3Q==
+bootstrap-vue-next@^0.42.0:
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-vue-next/-/bootstrap-vue-next-0.42.0.tgz#94d490215a2b11e670d66e67c61cdd2c1e183e40"
+  integrity sha512-CSkk2jL8Y2U9zgdutxjbBx4DRhKFmxTmaTQhhMYXVvczkVksw2mzRu1MU//950z0lvUwSqJo3R7y0opoyEA8zg==
 
 bootstrap@^5.3.7:
   version "5.3.7"
@@ -1818,7 +1855,7 @@ confbox@^0.1.8:
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
   integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
-confbox@^0.2.1:
+confbox@^0.2.1, confbox@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.2.2.tgz#8652f53961c74d9e081784beed78555974a9c110"
   integrity sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==
@@ -2573,6 +2610,11 @@ exsolve@^1.0.1:
   resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.5.tgz#1f5b6b4fe82ad6b28a173ccb955a635d77859dcf"
   integrity sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==
 
+exsolve@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.8.tgz#7f5e34da61cd1116deda5136e62292c096f50613"
+  integrity sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3215,6 +3257,15 @@ local-pkg@^1.1.1:
     pkg-types "^2.0.1"
     quansync "^0.2.8"
 
+local-pkg@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.2.tgz#c03d208787126445303f8161619dc701afa4abb5"
+  integrity sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==
+  dependencies:
+    mlly "^1.7.4"
+    pkg-types "^2.3.0"
+    quansync "^0.2.11"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3371,6 +3422,16 @@ mlly@^1.7.4:
     pkg-types "^1.3.0"
     ufo "^1.5.4"
 
+mlly@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.8.0.tgz#e074612b938af8eba1eaf43299cbc89cb72d824e"
+  integrity sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==
+  dependencies:
+    acorn "^8.15.0"
+    pathe "^2.0.3"
+    pkg-types "^1.3.1"
+    ufo "^1.6.1"
+
 mrmime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
@@ -3491,6 +3552,11 @@ nwsapi@^2.2.16:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.20.tgz#22e53253c61e7b0e7e93cef42c891154bcca11ef"
   integrity sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==
 
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3557,6 +3623,11 @@ package-json-from-dist@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
+package-manager-detector@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -3657,7 +3728,7 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-types@^1.3.0:
+pkg-types@^1.3.0, pkg-types@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
   integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
@@ -3673,6 +3744,15 @@ pkg-types@^2.0.1, pkg-types@^2.1.0:
   dependencies:
     confbox "^0.2.1"
     exsolve "^1.0.1"
+    pathe "^2.0.3"
+
+pkg-types@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-2.3.0.tgz#037f2c19bd5402966ff6810e32706558cb5b5726"
+  integrity sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==
+  dependencies:
+    confbox "^0.2.2"
+    exsolve "^1.0.7"
     pathe "^2.0.3"
 
 postcss-selector-parser@^6.0.15:
@@ -3748,6 +3828,11 @@ punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+quansync@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.11.tgz#f9c3adda2e1272e4f8cf3f1457b04cbdb4ee692a"
+  integrity sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==
 
 quansync@^0.2.8:
   version "0.2.10"
@@ -4127,6 +4212,11 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
+tinyexec@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.2.tgz#bdd2737fe2ba40bd6f918ae26642f264b99ca251"
+  integrity sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==
+
 tinyglobby@^0.2.12, tinyglobby@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
@@ -4298,6 +4388,11 @@ ufo@^1.5.4:
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
   integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
 
+ufo@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.3.tgz#799666e4e88c122a9659805e30b9dc071c3aed4f"
+  integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
+
 undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
@@ -4350,6 +4445,17 @@ unplugin-auto-import@^19.3.0:
     unplugin "^2.3.4"
     unplugin-utils "^0.2.4"
 
+unplugin-icons@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/unplugin-icons/-/unplugin-icons-23.0.1.tgz#aef196f5e0cb8121797ff22314e02063dc4fe04b"
+  integrity sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/utils" "^3.1.0"
+    local-pkg "^1.1.2"
+    obug "^2.1.1"
+    unplugin "^2.3.11"
+
 unplugin-utils@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/unplugin-utils/-/unplugin-utils-0.2.4.tgz#56e4029a6906645a10644f8befc404b06d5d24d0"
@@ -4379,6 +4485,16 @@ unplugin@^2.2.2, unplugin@^2.3.4, unplugin@^2.3.5:
   dependencies:
     acorn "^8.14.1"
     picomatch "^4.0.2"
+    webpack-virtual-modules "^0.6.2"
+
+unplugin@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-2.3.11.tgz#411e020dd2ba90e2fbe1e7bd63a5a399e6ee3b54"
+  integrity sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.5"
+    acorn "^8.15.0"
+    picomatch "^4.0.3"
     webpack-virtual-modules "^0.6.2"
 
 update-browserslist-db@^1.1.3:


### PR DESCRIPTION
Migrate icon system from @phosphor-icons/vue to unplugin-icons with automatic icon imports and update bootstrap-vue-next to v0.42.0. This is part of https://github.com/ICIJ/datashare/issues/1980.        
                                                                                                                                            
## Changes                                                                                                                                  
                                                                                                                                            
- Replace @phosphor-icons/vue with unplugin-icons and @iconify-json/ph for icon management                                                  
- Add unplugin-icons plugin to Vite with IconsResolver for automatic icon imports                                                           
- Update bootstrap-vue-next from v0.30.4 to v0.42.0                                                                                         
- Wrap application with BApp component in App.vue                                                                                           
- Update all components to use new icon syntax
- Refactor icon weight variants to use separate icon components (e.g., `IPhHandHeart` vs `IPhHandHeartFill`)                                
- Update useOs composable to return Vue Component types instead of icon name strings                                                        
- Remove custom icon tooling (bin/icons.ts, bin/presets/phosphor-vue.ts, bin/resolvers/phosphor-vue.ts)                                     
- Remove @phosphor-icons/vue from Vite optimizeDeps exclusions                                                                              
